### PR TITLE
chore(deps): update client-go to v0.7.0 and adjust API calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
-	github.com/thalassa-cloud/client-go v0.4.0
+	github.com/thalassa-cloud/client-go v0.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/thalassa-cloud/client-go v0.4.0 h1:ibhMZ1OyOqCcB4OzbRQiRHwQgcv+TsfP73cGvILTZgo=
-github.com/thalassa-cloud/client-go v0.4.0/go.mod h1:iViarJASos3qdQbIyup2jSHelVjry67M8acXcJhbdNI=
+github.com/thalassa-cloud/client-go v0.7.0 h1:cJrY6UVGA3M/9F8U+qSmDlbabSnSCU+gioA3DcCnnSw=
+github.com/thalassa-cloud/client-go v0.7.0/go.mod h1:70grZB37mMEmKsyoeSS/a8iUjJMHh1DmL51ypx3d5qA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/thalassa/data_source_machine_image.go
+++ b/thalassa/data_source_machine_image.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iaas "github.com/thalassa-cloud/client-go/iaas"
 )
 
 func dataSourceMachineImage() *schema.Resource {
@@ -45,7 +46,7 @@ func dataSourceMachineImageRead(ctx context.Context, d *schema.ResourceData, m i
 	provider := getProvider(m)
 	slug := d.Get("slug").(string)
 
-	machineImages, err := provider.Client.IaaS().ListMachineImages(ctx)
+	machineImages, err := provider.Client.IaaS().ListMachineImages(ctx, &iaas.ListMachineImagesRequest{})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/thalassa/data_source_machine_type.go
+++ b/thalassa/data_source_machine_type.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iaas "github.com/thalassa-cloud/client-go/iaas"
 )
 
 func dataSourceMachineType() *schema.Resource {
@@ -45,7 +46,7 @@ func dataSourceMachineTypeRead(ctx context.Context, d *schema.ResourceData, m in
 	provider := getProvider(m)
 	slug := d.Get("slug").(string)
 
-	machineTypes, err := provider.Client.IaaS().ListMachineTypes(ctx)
+	machineTypes, err := provider.Client.IaaS().ListMachineTypes(ctx, &iaas.ListMachineTypesRequest{})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/thalassa/data_source_region.go
+++ b/thalassa/data_source_region.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iaas "github.com/thalassa-cloud/client-go/iaas"
 )
 
 func dataSourceRegion() *schema.Resource {
@@ -45,7 +46,7 @@ func dataSourceRegionRead(ctx context.Context, d *schema.ResourceData, m interfa
 	provider := getProvider(m)
 	slug := d.Get("slug").(string)
 
-	regions, err := provider.Client.IaaS().ListRegions(ctx)
+	regions, err := provider.Client.IaaS().ListRegions(ctx, &iaas.ListRegionsRequest{})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/thalassa/data_source_regions.go
+++ b/thalassa/data_source_regions.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iaas "github.com/thalassa-cloud/client-go/iaas"
 )
 
 func dataSourceRegions() *schema.Resource {
@@ -66,7 +67,7 @@ func dataSourceRegions() *schema.Resource {
 func dataSourceRegionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	provider := getProvider(m)
 
-	regions, err := provider.Client.IaaS().ListRegions(ctx)
+	regions, err := provider.Client.IaaS().ListRegions(ctx, &iaas.ListRegionsRequest{})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/thalassa/resource_block_volume.go
+++ b/thalassa/resource_block_volume.go
@@ -106,7 +106,7 @@ func resourceBlockVolumeCreate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	region := d.Get("region").(string)
-	regions, err := client.IaaS().ListRegions(ctx)
+	regions, err := client.IaaS().ListRegions(ctx, &iaas.ListRegionsRequest{})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/thalassa/resource_kubernetes_cluster.go
+++ b/thalassa/resource_kubernetes_cluster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	validate "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	iaas "github.com/thalassa-cloud/client-go/iaas"
 	kubernetesclient "github.com/thalassa-cloud/client-go/kubernetesclient"
 	tcclient "github.com/thalassa-cloud/client-go/pkg/client"
 )
@@ -183,7 +184,7 @@ func resourceKubernetesClusterCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	region := d.Get("region").(string)
-	regions, err := client.IaaS().ListRegions(ctx)
+	regions, err := client.IaaS().ListRegions(ctx, &iaas.ListRegionsRequest{})
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
- Bump github.com/thalassa-cloud/client-go to v0.7.0
- update API calls in data sources and resources to use new request structures for listing machine images, machine types, and regions.