### PR TITLE
feat(iaas): support security group attachments on load balancers, natgateways

### DIFF
--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -80,6 +80,7 @@ output "loadbalancer_id" {
 - `external_ip_addresses` (List of String) The external IP addresses of the loadbalancer
 - `id` (String) The ID of this resource.
 - `ip_address` (String) The IP address of the loadbalancer
+- `security_group_attachments` (List of String) List identitties of security group that will be attached to the Loadbalancer
 - `slug` (String)
 - `vpc_id` (String) VPC of the Loadbalancer
 

--- a/docs/resources/natgateway.md
+++ b/docs/resources/natgateway.md
@@ -77,6 +77,7 @@ output "nat_gateway_endpoint_ip" {
 
 - `endpoint_ip` (String) Endpoint IP of the NatGateway
 - `id` (String) The ID of this resource.
+- `security_group_attachments` (List of String) List identitties of security group that will be attached to the NAT Gateway
 - `slug` (String)
 - `status` (String) Status of the NatGateway
 - `v4_ip` (String) V4 IP of the NatGateway

--- a/docs/resources/virtual_machine_instance.md
+++ b/docs/resources/virtual_machine_instance.md
@@ -144,7 +144,7 @@ output "load_balancer_port" {
 - `root_volume_id` (String) Root volume id of the virtual machine instance. Must be provided if root_volume_type is not set.
 - `root_volume_size_gb` (Number) Root volume size of the virtual machine instance. Must be provided if root_volume_id is not set.
 - `root_volume_type` (String) Root volume type of the virtual machine instance. Must be provided if root_volume_id is not set.
-- `security_group_attachments` (List of String) Security group attached to the virtual machine instance
+- `security_group_attachments` (List of String) List identitties of security group that will be attached to the Virtual Machine Instance
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/stretchr/testify v1.10.0
-	github.com/thalassa-cloud/client-go v0.16.1
+	github.com/thalassa-cloud/client-go v0.17.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/thalassa-cloud/client-go v0.16.1 h1:VzzW2QQRGWy/1BY0ew6kf3TnASGbdpAxstnsU94xDIg=
-github.com/thalassa-cloud/client-go v0.16.1/go.mod h1:xrEjSH5hUorL4JwzDiE1Z+0JHJLodNE49rqluZdB6P8=
+github.com/thalassa-cloud/client-go v0.17.1 h1:CJLHtwvOPVCa6qLpyw0r3ir5rvqjof3VpH/O4h7vJg0=
+github.com/thalassa-cloud/client-go v0.17.1/go.mod h1:xrEjSH5hUorL4JwzDiE1Z+0JHJLodNE49rqluZdB6P8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
- Updated the dependency `github.com/thalassa-cloud/client-go` from v0.16.1 to v0.17.1.
- Added `security_group_attachments` output to LoadBalancer, NAT Gateway, and Virtual Machine Instance documentation.
- Updated the resource definitions to include `security_group_attachments` for LoadBalancer, NAT Gateway, and Virtual Machine Instance, ensuring proper handling of security group identities.
