### PR TITLE
fix(dbaas): separate db_object_store_id from restore_from_backup_id

### DIFF
--- a/docs/resources/dbaas_db_cluster.md
+++ b/docs/resources/dbaas_db_cluster.md
@@ -49,7 +49,7 @@ resource "thalassa_dbaas_db_cluster" "example" {
   volume_type_class      = "block"
 
   # DB object storage is required for backups. Provision it with the cluster, or attach an
-  # existing store via restore_from_backup_id.
+  # existing store via db_object_store_id.
   provision_db_object_store = true
 
   # Create a final backup before destroy when the cluster is ready (default: true).
@@ -102,9 +102,10 @@ output "db_cluster_port" {
 - `maintenance_start_at` (Number) Start time of the maintenance window on the maintenance day in UTC. 0 is 00:00, 23 is 23:00
 - `organisation_id` (String) Reference to the Organisation of the Db Cluster. If not provided, the organisation of the (Terraform) provider will be used.
 - `parameters` (Map of String) Map of parameter name to database engine specific parameter value
-- `provision_db_object_store` (Boolean) Flag to indicate if the DB object store should be provisioned for the cluster. If true, restore_from_backup_id will be ignored.
+- `provision_db_object_store` (Boolean) Whether to provision a DB object store for the cluster. If true, db_object_store_id will be ignored.
 - `replicas` (Number) Number of instances in the cluster
-- `restore_from_backup_id` (String) Identity of the DB object store used for barman backups (optional). Ignored if provision_db_object_store is true.
+- `db_object_store_id` (String) Identity of an existing DB object store to use for barman backups. Ignored if provision_db_object_store is true.
+- `restore_from_backup_id` (String) Identity of the backup to restore from when creating the cluster.
 - `restore_recovery_target` (Block List, Max: 1) Recovery target for Point-In-Time Recovery (PITR). Only used when restore_from_backup_id is specified. (see [below for nested schema](#nestedblock--restore_recovery_target))
 - `security_groups` (List of String) List of security groups associated with the cluster
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/examples/resources/thalassa_dbaas_db_cluster/resource.tf
+++ b/examples/resources/thalassa_dbaas_db_cluster/resource.tf
@@ -33,7 +33,7 @@ resource "thalassa_dbaas_db_cluster" "example" {
   volume_type_class      = "block"
 
   # DB object storage is required for backups. Provision it with the cluster, or attach an
-  # existing store via restore_from_backup_id.
+  # existing store via db_object_store_id.
   provision_db_object_store = true
 
   # Create a final backup before destroy when the cluster is ready (default: true).

--- a/thalassa/dbaas/resource_db_cluster.go
+++ b/thalassa/dbaas/resource_db_cluster.go
@@ -287,14 +287,20 @@ func resourceDbCluster() *schema.Resource {
 			"restore_from_backup_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Identity of the DB object store used for barman backups (optional). Ignored if provision_db_object_store is true.",
+				Description: "ID of the backup to restore from when creating the cluster.",
+			},
+			"db_object_store_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "ID of an existing DB object store to use for backups. Ignored if provision_db_object_store is true.",
 			},
 			"provision_db_object_store": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				ForceNew:    true,
-				Description: "Flag to indicate if the DB object store should be provisioned for the cluster. If true, restore_from_backup_id will be ignored.",
+				Description: "Whether to provision a DB object store for the cluster. If true, db_object_store_id will be ignored.",
 			},
 			"create_backup_before_destroy": {
 				Type:        schema.TypeBool,
@@ -591,14 +597,14 @@ func resourceDbClusterCreate(ctx context.Context, d *schema.ResourceData, m any)
 	}
 
 	// Handle DB object store
-	if dbObjectStoreIdentity := d.Get("restore_from_backup_id"); dbObjectStoreIdentity != nil && dbObjectStoreIdentity != "" {
-		if strVal, ok := dbObjectStoreIdentity.(string); ok {
-			createDbCluster.DbObjectStoreIdentity = convert.Ptr(strVal)
-		}
-	}
 	if provisionDbObjectStore := d.Get("provision_db_object_store"); provisionDbObjectStore != nil {
 		if boolVal, ok := provisionDbObjectStore.(bool); ok {
 			createDbCluster.ProvisionDbObjectStore = boolVal
+		}
+	}
+	if !d.Get("provision_db_object_store").(bool) {
+		if dbObjectStoreIdentity, ok := d.GetOk("db_object_store_id"); ok {
+			createDbCluster.DbObjectStoreIdentity = convert.Ptr(dbObjectStoreIdentity.(string))
 		}
 	}
 
@@ -788,10 +794,8 @@ func resourceDbClusterUpdate(ctx context.Context, d *schema.ResourceData, m any)
 	}
 
 	// Handle DB object store
-	if dbObjectStoreIdentity := d.Get("restore_from_backup_id"); dbObjectStoreIdentity != nil && dbObjectStoreIdentity != "" {
-		if strVal, ok := dbObjectStoreIdentity.(string); ok {
-			updateDbCluster.DbObjectStoreIdentity = convert.Ptr(strVal)
-		}
+	if dbObjectStoreIdentity, ok := d.GetOk("db_object_store_id"); ok {
+		updateDbCluster.DbObjectStoreIdentity = convert.Ptr(dbObjectStoreIdentity.(string))
 	}
 
 	_, err = client.DBaaS().UpdateDbCluster(ctx, id, updateDbCluster)


### PR DESCRIPTION
restore_from_backup_id was incorrectly mapped to both RestoreFromBackupIdentity and DbObjectStoreIdentity. Introduce db_object_store_id for attaching an existing object store and reserve restore_from_backup_id for backup restore.