### PR TITLE
fix(objectstorage): allow wildcard principals in bucket policy validation

### DIFF
--- a/thalassa/objectstorage/bucket_policy.go
+++ b/thalassa/objectstorage/bucket_policy.go
@@ -63,6 +63,16 @@ func thalassaPrincipalARNs(raw any) []string {
 	}
 }
 
+var (
+	expectedPrincipalARNs = []string{
+		"*",
+		"arn:thalassa:iam:::serviceaccount/<organisation-id>:<service-account-id>",
+		"arn:thalassa:iam:::serviceaccount/<organisation-id>/*",
+		"arn:thalassa:iam:::user/<organisation-id>:<user-id>",
+		"arn:thalassa:iam:::user/<organisation-id>/*",
+	}
+)
+
 func validateThalassaPrincipalARN(arn string) error {
 	arn = strings.TrimSpace(arn)
 	if arn == "" {
@@ -74,8 +84,9 @@ func validateThalassaPrincipalARN(arn string) error {
 	}
 
 	return fmt.Errorf(
-		"invalid Principal.Thalassa ARN %q: expected \"*\", arn:thalassa:iam:::serviceaccount/<organisation-id>:<service-account-id>, arn:thalassa:iam:::serviceaccount/<organisation-id>/*, arn:thalassa:iam:::user/<organisation-id>:<user-id>, or arn:thalassa:iam:::user/<organisation-id>/*",
+		"invalid Principal.Thalassa ARN %q: expected one of %s",
 		arn,
+		strings.Join(expectedPrincipalARNs, ", "),
 	)
 }
 

--- a/thalassa/objectstorage/bucket_policy.go
+++ b/thalassa/objectstorage/bucket_policy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/thalassa-cloud/client-go/objectstorage"
 )
 
-var thalassaServiceAccountPrincipalPattern = regexp.MustCompile(`^arn:thalassa:iam:::serviceaccount/[^:]+:[^:]+$`)
+var thalassaPrincipalARNPattern = regexp.MustCompile(`^arn:thalassa:iam:::(?:serviceaccount|user)/[^:]+:(?:[^:]+|\*)$`)
 
 func parseBucketPolicyJSON(raw string) (*objectstorage.PolicyDocument, error) {
 	if raw == "" {
@@ -69,12 +69,12 @@ func validateThalassaPrincipalARN(arn string) error {
 		return fmt.Errorf("Principal.Thalassa ARN cannot be empty")
 	}
 
-	if thalassaServiceAccountPrincipalPattern.MatchString(arn) {
+	if arn == "*" || thalassaPrincipalARNPattern.MatchString(arn) {
 		return nil
 	}
 
 	return fmt.Errorf(
-		"invalid Principal.Thalassa ARN %q: expected arn:thalassa:iam:::serviceaccount/<organisation-id>:<service-account-id>",
+		"invalid Principal.Thalassa ARN %q: expected \"*\", arn:thalassa:iam:::serviceaccount/<organisation-id>:<service-account-id>, arn:thalassa:iam:::serviceaccount/<organisation-id>/*, arn:thalassa:iam:::user/<organisation-id>:<user-id>, or arn:thalassa:iam:::user/<organisation-id>/*",
 		arn,
 	)
 }
@@ -87,8 +87,11 @@ func enrichBucketError(err error, action string) error {
 	if strings.Contains(strings.ToLower(err.Error()), "invalid principal arn") {
 		return fmt.Errorf(
 			"failed to %s bucket: the policy contains an invalid Principal.Thalassa ARN. "+
-				"Use a service account principal such as "+
-				"arn:thalassa:iam:::serviceaccount/<organisation-id>:<service-account-id>: %w",
+				"Use \"*\", a service account principal such as "+
+				"arn:thalassa:iam:::serviceaccount/<organisation-id>:<service-account-id>, "+
+				"arn:thalassa:iam:::serviceaccount/<organisation-id>/*, "+
+				"or a user principal such as arn:thalassa:iam:::user/<organisation-id>:<user-id> or "+
+				"arn:thalassa:iam:::user/<organisation-id>/*: %w",
 			action,
 			err,
 		)

--- a/thalassa/objectstorage/bucket_policy_test.go
+++ b/thalassa/objectstorage/bucket_policy_test.go
@@ -22,8 +22,29 @@ func TestValidateThalassaPrincipalARN(t *testing.T) {
 			arn:  "arn:thalassa:iam:::serviceaccount/o-org123:sa-account456",
 		},
 		{
+			name: "valid service account wildcard principal",
+			arn:  "arn:thalassa:iam:::serviceaccount/o-org123:*",
+		},
+		{
+			name: "valid user principal",
+			arn:  "arn:thalassa:iam:::user/o-org123:u-user456",
+		},
+		{
+			name: "valid user wildcard principal",
+			arn:  "arn:thalassa:iam:::user/o-org123:*",
+		},
+		{
+			name: "wildcard principal (allow public access)",
+			arn:  "*",
+		},
+		{
 			name:    "invalid colon-separated principal",
 			arn:     "arn:thalassa:iam:::serviceaccount:o-org123:sa-account456",
+			wantErr: "invalid Principal.Thalassa ARN",
+		},
+		{
+			name:    "invalid colon-separated user principal",
+			arn:     "arn:thalassa:iam:::user:o-org123:u-user456",
 			wantErr: "invalid Principal.Thalassa ARN",
 		},
 		{
@@ -120,5 +141,9 @@ func TestEnrichBucketError(t *testing.T) {
 	err := enrichBucketError(fmt.Errorf("bad request: invalid principal ARN"), "create")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create bucket")
+	assert.Contains(t, err.Error(), `"*"`)
 	assert.Contains(t, err.Error(), "serviceaccount/<organisation-id>:<service-account-id>")
+	assert.Contains(t, err.Error(), "serviceaccount/<organisation-id>/*")
+	assert.Contains(t, err.Error(), "user/<organisation-id>:<user-id>")
+	assert.Contains(t, err.Error(), "user/<organisation-id>/*")
 }


### PR DESCRIPTION
Support wildcard ARNs for both serviceaccount and user principals, and update validation/error-path tests accordingly.

This broke in recent release when we introduced validation for principals in policy documents.